### PR TITLE
suppress unnecessary output

### DIFF
--- a/functions/create_events/lambda_function.py
+++ b/functions/create_events/lambda_function.py
@@ -48,7 +48,7 @@ def lambda_handler(event, context):
             }
         }
 
-        r = create_events(events,context)
-        return r
+        create_events(events,context)
+        return {"completed": True}
 
     return socless_bootstrap(event,context, handle_state, include_event=True)


### PR DESCRIPTION
socless_create_events integration currently returns a list of execution_ids for all the events that were created. If the list is too big, AWS Step Functions will fail. 
The data hasn't proven to be useful, so we've suppressed it to prevent failures.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
