### PR TITLE
add slack invitation link to socless docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Features
 - Serverless design has low cost, low operational overhead, and scales effortlessly
 
 Ready? Check out the [docs!](https://twilio-labs.github.io/socless/)
+
+
+Join our community Slack workspace @ https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Features
 Ready? Check out the [docs!](https://twilio-labs.github.io/socless/)
 
 
-Join our community Slack workspace @ https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg
+Join our [community Slack workspace](https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg)

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,1 +1,3 @@
 # About SOCless
+
+Join our community Slack workspace @ https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,3 +1,3 @@
 # About SOCless
 
-Join our community Slack workspace @ https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg
+Join our [community Slack workspace](https://join.slack.com/t/socless/shared_invite/enQtODA3ODEzNzcwNDgxLTBiYjVjYjI4ODI4YTY5YzM4OWRlYjQ1Yzg4M2EzMGUzMGMyYThlN2U5NTI5OWIwZWE1ZTcwNjA2MjgyZDRmMjg)


### PR DESCRIPTION
To grow the SOCless community, this PR adds a Slack Workspace invitation link to the socless docs `/about` page as well as the github repo `README`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
