### PR TITLE
add socless_template_string to read findings parameter

### DIFF
--- a/functions/socless_log_findings/lambda_function.py
+++ b/functions/socless_log_findings/lambda_function.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from socless import socless_bootstrap, gen_id, save_to_s3
+from socless import socless_bootstrap, gen_id, save_to_s3, socless_template_string
 from datetime import datetime
+import urllib.parse
 import boto3
 import json
 import os
@@ -63,10 +64,16 @@ def lambda_handler(event, context):
             "investigation_id": investigation_id,
             "event_type": event_type,
             "event_payload": event_payload,
-            "findings" : findings,
             "investigation_escalated" : investigation_escalated,
             "metadata" : metadata
         }
+
+        try:
+            findings = socless_template_string(urllib.parse.unquote(findings),context)
+        except Exception as e:
+            print(f'unable to parse socless_template_string. Error: {e}. Findings: {findings}')
+        
+        log['findings'] = findings
 
         return save_to_s3(file_id, log, bucket_name, False)
 


### PR DESCRIPTION
Use socless_template_string() on the "findings" parameter to allow embedded values from the Step Functions context inside of the findings string.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
