### PR TITLE
Repoint from github/twilio to github/twilio-labs

### DIFF
--- a/docs/your-first-integration-geolocating-an-ip.md
+++ b/docs/your-first-integration-geolocating-an-ip.md
@@ -33,7 +33,7 @@ To begin, change out of socless directory at your command-line (if you’re stil
 Next, run the commands below to download the `socless-integrations-template` which contains the pre-configurations we need for developing our Integration
 
 ```
-git clone git@github.com:twilio/socless-integrations-template.git socless-tutorial
+git clone git@github.com:twilio-labs/socless-integrations-template.git socless-tutorial
 cd socless-tutorial
 ./setup
 virtualenv --python=python3.7 venv


### PR DESCRIPTION
Ensure that integration template URLs are pointing to twilio-labs

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
