### PR TITLE
Bump log findings function memory and timeout because it times out occasionally

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,14 +29,14 @@ provider:
       - Ref: SoclessPrivateFunctionSubnet
 
 plugins:
-  - sls-apb 
+  - sls-apb
   - socless_integration_packager
 
 custom:
   soclessPackager:
     buildDir: build
   playbooksLogGroupName: /socless/playbook-execution-logs
-  # This is an example of an Integration Test playbook. 
+  # This is an example of an Integration Test playbook.
   # The integration test can be used to ensure that deployed functions will work correctly in a playbook environment
   playbooks:
     - socless_core_integration_test
@@ -70,8 +70,7 @@ resources:
           Fn::Sub: ${MergeParallelOutputLambdaFunction.Arn}
 
       SaveMessageResponseToken:
-        Description: Save the task token created when the Socless Messages Response
-          Activity state is used
+        Description: Save the task token created when the Socless Messages Response Activity state is used
         Value:
           Fn::Sub: ${SaveMessageResponseTokenLambdaFunction.Arn}
 
@@ -121,12 +120,11 @@ resources:
         Description: Make requests against AWS APIs
         Value:
           Fn::Sub: ${AWSRequestLambdaFunction.Arn}
-      
+
       SetupGlobalStateForDirectInvokedPlaybook:
         Description: Make requests against AWS APIs
         Value:
           Fn::Sub: ${SetupGlobalStateForDirectInvokedPlaybookLambdaFunction.Arn}
-
 
 package:
   individually: true
@@ -151,8 +149,7 @@ functions:
   SaveMessageResponseToken:
     handler: lambda_function.lambda_handler
     name: _socless_save_msg_resp_token
-    description: Save the task token created when the Socless Messages Response Activity
-      state is used
+    description: Save the task token created when the Socless Messages Response Activity state is used
     environment:
       AWAIT_MESSAGE_RESPONSE_ARN:
         Ref: AwaitMessageResponseActivity
@@ -264,6 +261,8 @@ functions:
     handler: lambda_function.lambda_handler
     name: socless_log_findings
     description: Generate and upload SOCless log findings to a logging bucket
+    memorySize: 512
+    timeout: 60
     environment:
       SOCLESS_Logs:
         Ref: SoclessLogs


### PR DESCRIPTION
Bump log findings function memory and timeout because it times out occasionally

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
