### PR TITLE
deprecate socless_template_string

### DIFF
--- a/functions/cache_results/lambda_function.py
+++ b/functions/cache_results/lambda_function.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 from typing import Any
-from socless import socless_bootstrap, socless_template_string
+from socless import socless_bootstrap
 
 
 def handle_state(execution_context, entries: Any):
@@ -28,13 +28,11 @@ def handle_state(execution_context, entries: Any):
         A dictionary that contains the thing you want to be cached.
         {"cached": data}
     """
-    if isinstance(entries, str):
-        entries = socless_template_string(entries, execution_context)
-    elif isinstance(entries, dict):
+    if isinstance(entries, dict):
         new_entries = {}
         for key, value in list(entries.items()):
             if isinstance(value, str):
-                new_entries[key] = socless_template_string(value, execution_context)
+                new_entries[key] = value
             else:
                 new_entries[key] = value
         entries = new_entries

--- a/functions/socless_log_findings/lambda_function.py
+++ b/functions/socless_log_findings/lambda_function.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from socless import socless_bootstrap, gen_id, save_to_s3, socless_template_string
+from socless import socless_bootstrap, gen_id, save_to_s3
 from datetime import datetime
 import urllib.parse
 import os
@@ -76,10 +76,10 @@ def lambda_handler(event, ctx):
         }
 
         try:
-            findings = socless_template_string(urllib.parse.unquote(findings), context)
+            findings = urllib.parse.unquote(findings)
         except Exception as e:
             print(
-                f"unable to parse socless_template_string. Error: {e}. Findings: {findings}"
+                f"unable to parse findings. Error: {e}. Findings: {findings}"
             )
             raise
 


### PR DESCRIPTION
This is to deprecate old API: socless_template_string

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
